### PR TITLE
fix: use correct craft description in action publish

### DIFF
--- a/packages/asset-manager/src/entries.ts
+++ b/packages/asset-manager/src/entries.ts
@@ -228,7 +228,9 @@ export function setupEntries (): void {
             ['NextAsset', NextItem],
         ] as const) {
             const customed = checkItemCustomed(item);
-            if (customed) dictionary.text(key, item.Asset.Description);
+            // Add an extra 'text' tag here in order to display the name or custom name of plugin items to clients without the plugin.
+            // Without this tag, or if using the asset tag, the item name will display incorrectly for users without the plugin.
+            if(customed) dictionary.text(key, item.Craft?.Name ?? item.Asset.Description );
         }
     });
 }


### PR DESCRIPTION
If possible, use craft name instead of item's original description while building "ChatRoomPublishAction" message.