### PR TITLE
chore: update all dependencies for BC R128

### DIFF
--- a/packages/activity-manager/package.json
+++ b/packages/activity-manager/package.json
@@ -37,7 +37,7 @@
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.4",
     "@sugarch/bc-image-mapping": "workspace:*",
-    "bc-stubs": "126.0.0",
+    "bc-stubs": "128.0.0-Alpha.1",
     "eventemitter3": "^5.0.1",
     "rollup": "^4.59.0",
     "rollup-plugin-delete": "^3.0.1",

--- a/packages/asset-manager/package.json
+++ b/packages/asset-manager/package.json
@@ -37,7 +37,7 @@
     "@rollup/plugin-typescript": "^12.1.4",
     "@sugarch/bc-image-mapping": "workspace:*",
     "@sugarch/bc-mod-utility": "workspace:*",
-    "bc-stubs": "126.0.0",
+    "bc-stubs": "128.0.0-Alpha.1",
     "bondage-club-mod-sdk": "^1.2.0",
     "rollup": "^4.59.0",
     "rollup-plugin-delete": "^3.0.1",

--- a/packages/asset-manager/src/assetUtils.ts
+++ b/packages/asset-manager/src/assetUtils.ts
@@ -1,11 +1,11 @@
 import { HookManager } from '@sugarch/bc-mod-hook-manager';
 import { AssetConfig, ParsedAsset, resolveStringAsset } from './assetConfigs';
-import { customAssetAdd, customAssetMarkStrict, getCustomAssets } from './customStash';
+import { customAssetAdd, customAssetMarkStrict, getCustomAssets, getCustomGroupDefs } from './customStash';
 import { addCustomAssetStringWithPrefix } from './dialog';
 import { Entries, resolveEntry, solidfyEntry } from './entries';
 import { addLayerNames } from './layerNames';
 import { pushAfterLoad, pushAssetLoadEvent, pushDefsLoad, requireGroup } from './loadSchedule';
-import type { CustomAssetDefinition, CustomGroupName, FuncWork, Translation } from '@sugarch/bc-mod-types';
+import type { CustomAssetDefinition, CustomGroupDefinition, CustomGroupName, FuncWork, Translation } from '@sugarch/bc-mod-types';
 
 /**
  * Mirror a global function between asset groups
@@ -73,6 +73,14 @@ export function loadAsset<Custom extends string = AssetGroupBodyName> (
         // Note that this function is called once for each mirrored body group, so we can't use the outer groupName
         // Using const shadowing to avoid this problem
         const groupName = groupObj.Name;
+
+        let groupDef = AssetFemale3DCG.find(g => g.Group === groupName);
+        if (!groupDef) groupDef = getCustomGroupDefs<AssetGroupName>()[groupName];
+        if (!groupDef) {
+            console.error(`missing group definition for "${groupName}"`);
+            return;
+        }
+
         const assetDef = resolveStringAsset(asset as AssetDefinition);
 
         const assetDefRes = AssetResolveCopyConfig.AssetDefinition(assetDef, groupName, ParsedAsset.value);
@@ -85,7 +93,7 @@ export function loadAsset<Custom extends string = AssetGroupBodyName> (
         }
 
         // First set the display name here
-        customAssetAdd(groupObj, assetDefRes, AssetConfig.value).then(asset => {
+        customAssetAdd(groupObj, assetDefRes, AssetConfig.value, groupDef).then(asset => {
             if (asset.DynamicGroupName === asset.Group.Name) {
                 if (dynamicName) asset.DynamicGroupName = dynamicName as AssetGroupName;
                 else asset.DynamicGroupName = srcGroupName as AssetGroupName;

--- a/packages/asset-manager/src/customStash.ts
+++ b/packages/asset-manager/src/customStash.ts
@@ -1,9 +1,10 @@
 import { HookManager, HookManagerInterface } from '@sugarch/bc-mod-hook-manager';
-import type { CustomGroupName } from '@sugarch/bc-mod-types';
+import type { CustomGroupDefinition, CustomGroupName } from '@sugarch/bc-mod-types';
 import { SyncPromise } from './syncPromise';
 import { queryMirrorPreimage } from './mirrorGroup';
 
 const customGroups: Record<string, AssetGroup> = {};
+const customGroupDefs: Record<string, AssetGroupDefinition> = {};
 
 const customAssets: Record<string, Record<string, Asset>> = {};
 
@@ -22,6 +23,8 @@ export function customGroupAdd(
 ): SyncPromise<Mutable<AssetGroup>> {
     // Prevent the addition process from being disrupted
     const Group = HookManager.invokeOriginal('AssetGroupAdd', family, groupDef);
+    console.log("customGroupAdd:", family, groupDef);
+    customGroupDefs[groupDef.Group] = groupDef;
     customGroups[Group.Name] = Group;
     return SyncPromise.resolve(Group as Mutable<AssetGroup>);
 }
@@ -40,9 +43,9 @@ export function customAssetGetStrict(name: string): Asset | undefined {
 /**
  * Add a custom asset
  */
-export function customAssetAdd(...[group, assetDef, config]: Parameters<typeof AssetAdd>): SyncPromise<Mutable<Asset>> {
+export function customAssetAdd(...[group, assetDef, config, groupDef]: Parameters<typeof AssetAdd>): SyncPromise<Mutable<Asset>> {
     // Prevent the addition process from being disrupted
-    HookManager.invokeOriginal('AssetAdd', group, assetDef, config);
+    HookManager.invokeOriginal('AssetAdd', group, assetDef, config, groupDef);
     const groupName = group.Name;
     const assetName = assetDef.Name;
     if (!customAssets[groupName]) customAssets[groupName] = {};
@@ -54,6 +57,16 @@ export function customAssetAdd(...[group, assetDef, config]: Parameters<typeof A
 
     // NOTE: This situation should not be possible
     return SyncPromise.reject(`Asset ${groupName}:${assetName} not found`);
+}
+
+/**
+ * Get all custom groups
+ */
+export function getCustomGroupDefs<Custom extends string = AssetGroupBodyName>(): Record<
+    CustomGroupName<Custom>,
+    AssetGroupDefinition
+> {
+    return customGroupDefs as Record<CustomGroupName<Custom>, AssetGroupDefinition>;
 }
 
 /**

--- a/packages/event-handler/package.json
+++ b/packages/event-handler/package.json
@@ -36,7 +36,7 @@
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.4",
     "@sugarch/bc-mod-utility": "workspace:*",
-    "bc-stubs": "126.0.0",
+    "bc-stubs": "128.0.0-Alpha.1",
     "eventemitter3": "^5.0.1",
     "rollup": "^4.59.0",
     "rollup-plugin-delete": "^3.0.1",

--- a/packages/image-mapping/package.json
+++ b/packages/image-mapping/package.json
@@ -41,7 +41,7 @@
     "@rollup/plugin-typescript": "^12.1.4",
     "@sugarch/bc-mod-hook-manager": "workspace:*",
     "@types/jest": "^29.5.14",
-    "bc-stubs": "126.0.0",
+    "bc-stubs": "128.0.0-Alpha.1",
     "bondage-club-mod-sdk": "^1.2.0",
     "jest": "^29.7.0",
     "rollup": "^4.59.0",

--- a/packages/mod-hook-manager/package.json
+++ b/packages/mod-hook-manager/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.4",
-    "bc-stubs": "126.0.0",
+    "bc-stubs": "128.0.0-Alpha.1",
     "bondage-club-mod-sdk": "^1.2.0",
     "rollup": "^4.59.0",
     "rollup-plugin-delete": "^3.0.1",

--- a/packages/mod-i18n/package.json
+++ b/packages/mod-i18n/package.json
@@ -34,7 +34,7 @@
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.4",
-    "bc-stubs": "126.0.0",
+    "bc-stubs": "128.0.0-Alpha.1",
     "rollup": "^4.59.0",
     "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-delete": "^3.0.1",

--- a/packages/mod-types/package.json
+++ b/packages/mod-types/package.json
@@ -22,7 +22,7 @@
     "url": "git+https://github.com/SugarChain-Studio/sugarch-utilities.git"
   },
   "devDependencies": {
-    "bc-stubs": "126.0.0",
+    "bc-stubs": "128.0.0-Alpha.1",
     "rollup": "^4.59.0",
     "typescript": "^5.9.2"
   }

--- a/packages/mod-utility/package.json
+++ b/packages/mod-utility/package.json
@@ -31,7 +31,7 @@
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.4",
-    "bc-stubs": "126.0.0",
+    "bc-stubs": "128.0.0-Alpha.1",
     "rollup": "^4.59.0",
     "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-delete": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ importers:
         specifier: workspace:*
         version: link:../image-mapping
       bc-stubs:
-        specifier: 126.0.0
-        version: 126.0.0
+        specifier: 128.0.0-Alpha.1
+        version: 128.0.0-Alpha.1
       eventemitter3:
         specifier: ^5.0.1
         version: 5.0.1
@@ -120,8 +120,8 @@ importers:
         specifier: workspace:*
         version: link:../mod-utility
       bc-stubs:
-        specifier: 126.0.0
-        version: 126.0.0
+        specifier: 128.0.0-Alpha.1
+        version: 128.0.0-Alpha.1
       bondage-club-mod-sdk:
         specifier: ^1.2.0
         version: 1.2.0
@@ -169,8 +169,8 @@ importers:
         specifier: workspace:*
         version: link:../mod-utility
       bc-stubs:
-        specifier: 126.0.0
-        version: 126.0.0
+        specifier: 128.0.0-Alpha.1
+        version: 128.0.0-Alpha.1
       eventemitter3:
         specifier: ^5.0.1
         version: 5.0.1
@@ -224,8 +224,8 @@ importers:
         specifier: ^29.5.14
         version: 29.5.14
       bc-stubs:
-        specifier: 126.0.0
-        version: 126.0.0
+        specifier: 128.0.0-Alpha.1
+        version: 128.0.0-Alpha.1
       bondage-club-mod-sdk:
         specifier: ^1.2.0
         version: 1.2.0
@@ -261,8 +261,8 @@ importers:
         specifier: ^12.1.4
         version: 12.1.4(rollup@4.59.0)(tslib@2.8.1)(typescript@5.9.2)
       bc-stubs:
-        specifier: 126.0.0
-        version: 126.0.0
+        specifier: 128.0.0-Alpha.1
+        version: 128.0.0-Alpha.1
       bondage-club-mod-sdk:
         specifier: ^1.2.0
         version: 1.2.0
@@ -298,8 +298,8 @@ importers:
         specifier: ^12.1.4
         version: 12.1.4(rollup@4.59.0)(tslib@2.8.1)(typescript@5.9.2)
       bc-stubs:
-        specifier: 126.0.0
-        version: 126.0.0
+        specifier: 128.0.0-Alpha.1
+        version: 128.0.0-Alpha.1
       rollup:
         specifier: ^4.59.0
         version: 4.59.0
@@ -319,8 +319,8 @@ importers:
   packages/mod-types:
     devDependencies:
       bc-stubs:
-        specifier: 126.0.0
-        version: 126.0.0
+        specifier: 128.0.0-Alpha.1
+        version: 128.0.0-Alpha.1
       rollup:
         specifier: ^4.59.0
         version: 4.59.0
@@ -350,8 +350,8 @@ importers:
         specifier: ^12.1.4
         version: 12.1.4(rollup@4.59.0)(tslib@2.8.1)(typescript@5.9.2)
       bc-stubs:
-        specifier: 126.0.0
-        version: 126.0.0
+        specifier: 128.0.0-Alpha.1
+        version: 128.0.0-Alpha.1
       rollup:
         specifier: ^4.59.0
         version: 4.59.0
@@ -985,6 +985,9 @@ packages:
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
+  '@total-typescript/ts-reset@0.6.1':
+    resolution: {integrity: sha512-cka47fVSo6lfQDIATYqb/vO1nvFfbPw7uWLayIXIhGETj0wcOOlrlkobOMDNQOFr9QOafegUPq13V2+6vtD7yg==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -1192,8 +1195,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  bc-stubs@126.0.0:
-    resolution: {integrity: sha512-391/Y2F/b5Fwh02QCu+M4pcuwtXbhWypO/VaNp7ItKucj5C9paWX9NA4mTQ3oBI5a6DGrXkv8Xer5tF4EfVxbA==}
+  bc-stubs@128.0.0-Alpha.1:
+    resolution: {integrity: sha512-B84YIfwJc9mvSW3BXHq6ZLQApfWdm0Ozzvi/FLG+eCHXOWaa9pMACCgXoweL55oHfEYQC37UXUfGpx21hpp7TA==}
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -3238,6 +3241,8 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
+  '@total-typescript/ts-reset@0.6.1': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.28.0
@@ -3505,8 +3510,9 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  bc-stubs@126.0.0:
+  bc-stubs@128.0.0-Alpha.1:
     dependencies:
+      '@total-typescript/ts-reset': 0.6.1
       socket.io-client: 4.6.1
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
This fixes the thrown exception from the change to AssetAdd now needing to have the group definition as well.